### PR TITLE
Release 0.2.7

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -1,4 +1,4 @@
-# Ceate an OpenAI compatible API server for your LLM
+# Create an OpenAI compatible API server for your LLM
 
 An OpenAI-compatible web API allows the model to work with a large ecosystem of LLM tools and agent frameworks such as flows.network, LangChain and LlamaIndex.
 
@@ -6,7 +6,7 @@ An OpenAI-compatible web API allows the model to work with a large ecosystem of 
 
 <!-- code_chunk_output -->
 
-- [Ceate an OpenAI compatible API server for your LLM](#ceate-an-openai-compatible-api-server-for-your-llm)
+- [Create an OpenAI compatible API server for your LLM](#create-an-openai-compatible-api-server-for-your-llm)
   - [Dependencies](#dependencies)
   - [Get the llama-api-server.wasm app](#get-the-llama-api-serverwasm-app)
   - [Get model](#get-model)

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [dependencies]

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [dependencies]

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -322,7 +322,13 @@ fn main() -> Result<(), String> {
         print_log_end_separator(Some("*"), None);
     }
 
-    print_log_end_separator(Some("-"), None);
+    let readme = "
+================================== Running in interactive mode. ===================================\n
+    - Press [Return] twice to end the input.
+    - Press [Ctrl+C] to interject at any time.
+    - To submit another line, end your input with '\\' and press [Return].\n";
+
+    println!("{}", readme);
 
     loop {
         println!("\n[You]: ");

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes

- Llama-api-server
  - Improve the `ContextFull` and `PromptTooLong` cases in the stream mode
  - Improve the design for building prompts
  - Improve the setting of the `n_predict` metadata option
  - Fix a typo in `README`

- Llama-chat
  - Add the description for the operations in the console

