### PR TITLE
Release 0.2.10

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -231,7 +231,7 @@ The `-h` or `--help` option can list the available options of the `llama-api-ser
     -r, --reverse-prompt <REVERSE_PROMPT>
             Halt generation at PROMPT, return control.
     -p, --prompt-template <TEMPLATE>
-            Sets the prompt template. [default: llama-2-chat] [possible values: llama-2-chat, codellama-instruct, mistral-instruct-v0.1, mistral-instruct, mistrallite, openchat, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct]
+            Sets the prompt template. [default: llama-2-chat] [possible values: llama-2-chat, codellama-instruct, codellama-super-instruct, mistral-instruct-v0.1, mistral-instruct, mistrallite, openchat, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct]
         --log-prompts
             Print prompt strings to stdout
         --log-stat

--- a/api-server/chat-prompts/src/chat/llama.rs
+++ b/api-server/chat-prompts/src/chat/llama.rs
@@ -290,7 +290,7 @@ impl BuildChatPrompt for CodeLlamaSuperInstructPrompt {
             }
         }
 
-        prompt.push_str(" Source: assistant\nDestination: user\n\n ");
+        prompt.push_str(" Destination: user\n\n ");
 
         Ok(prompt)
     }

--- a/api-server/chat-prompts/src/chat/llama.rs
+++ b/api-server/chat-prompts/src/chat/llama.rs
@@ -205,3 +205,93 @@ impl BuildChatPrompt for CodeLlamaInstructPrompt {
         Ok(prompt)
     }
 }
+
+/// Generate prompts for the `Codellama-instruct` model.
+#[derive(Debug, Default, Clone)]
+pub struct CodeLlamaSuperInstructPrompt;
+impl CodeLlamaSuperInstructPrompt {
+    /// Create a system prompt from a chat completion request message.
+    fn create_system_prompt(&self, system_message: &ChatCompletionRequestMessage) -> String {
+        let content = system_message.content.as_str();
+        match content.is_empty() {
+            true => String::from("<s>Source: system\n\n You are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe. <step>"),
+            false => format!(
+                "<s>Source: system\n\n {content} <step>"
+            )
+        }
+    }
+
+    /// Create a user prompt from a chat completion request message.
+    fn append_user_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        system_prompt: impl AsRef<str>,
+        content: impl AsRef<str>,
+    ) -> String {
+        match chat_history.as_ref().is_empty() {
+            true => format!(
+                "{system_prompt} Source: user\n\n {user_message} <step>",
+                system_prompt = system_prompt.as_ref().trim(),
+                user_message = content.as_ref().trim(),
+            ),
+            false => format!(
+                "{chat_history} Source: user\n\n {user_message} <step>",
+                chat_history = chat_history.as_ref().trim(),
+                user_message = content.as_ref().trim(),
+            ),
+        }
+    }
+
+    /// create an assistant prompt from a chat completion request message.
+    fn append_assistant_message(
+        &self,
+        chat_history: impl AsRef<str>,
+        content: impl AsRef<str>,
+    ) -> String {
+        format!(
+            "{prompt} Source: assistant\n\n {assistant_message} <step>",
+            prompt = chat_history.as_ref().trim(),
+            assistant_message = content.as_ref().trim(),
+        )
+    }
+}
+impl BuildChatPrompt for CodeLlamaSuperInstructPrompt {
+    fn build(&self, messages: &mut Vec<ChatCompletionRequestMessage>) -> Result<String> {
+        if messages.is_empty() {
+            return Ok(String::new());
+        }
+
+        // systemp prompt
+        let system_prompt = if messages[0].role == ChatCompletionRole::System {
+            self.create_system_prompt(&messages[0])
+        } else {
+            String::from("<<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe. <</SYS>>")
+        };
+
+        // append user/assistant messages
+        if messages.is_empty() {
+            return Err(crate::error::PromptError::NoMessages);
+        }
+
+        let mut prompt = String::new();
+        for message in messages {
+            match message.role {
+                ChatCompletionRole::System => continue,
+                ChatCompletionRole::User => {
+                    prompt =
+                        self.append_user_message(&prompt, &system_prompt, message.content.as_str());
+                }
+                ChatCompletionRole::Assistant => {
+                    prompt = self.append_assistant_message(&prompt, message.content.as_str());
+                }
+                _ => {
+                    return Err(crate::error::PromptError::UnknownRole(message.role));
+                }
+            }
+        }
+
+        prompt.push_str(" Source: assistant\nDestination: user\n\n ");
+
+        Ok(prompt)
+    }
+}

--- a/api-server/chat-prompts/src/chat/llama.rs
+++ b/api-server/chat-prompts/src/chat/llama.rs
@@ -265,7 +265,7 @@ impl BuildChatPrompt for CodeLlamaSuperInstructPrompt {
         let system_prompt = if messages[0].role == ChatCompletionRole::System {
             self.create_system_prompt(&messages[0])
         } else {
-            String::from("<<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe. <</SYS>>")
+            String::from("<s>Source: system\n\n You are a helpful, respectful and honest assistant. Always answer as short as possible, while being safe. <step>")
         };
 
         // append user/assistant messages

--- a/api-server/chat-prompts/src/chat/llama.rs
+++ b/api-server/chat-prompts/src/chat/llama.rs
@@ -290,7 +290,7 @@ impl BuildChatPrompt for CodeLlamaSuperInstructPrompt {
             }
         }
 
-        prompt.push_str(" Destination: user\n\n ");
+        prompt.push_str(" Destination:");
 
         Ok(prompt)
     }

--- a/api-server/chat-prompts/src/chat/llama.rs
+++ b/api-server/chat-prompts/src/chat/llama.rs
@@ -96,10 +96,6 @@ impl BuildChatPrompt for Llama2ChatPrompt {
             }
         }
 
-        // println!("*** [prompt begin] ***");
-        // println!("{}", &prompt);
-        // println!("*** [prompt end] ***");
-
         Ok(prompt)
     }
 }
@@ -198,15 +194,11 @@ impl BuildChatPrompt for CodeLlamaInstructPrompt {
             }
         }
 
-        // println!("*** [prompt begin] ***");
-        // println!("{}", &prompt);
-        // println!("*** [prompt end] ***");
-
         Ok(prompt)
     }
 }
 
-/// Generate prompts for the `Codellama-instruct` model.
+/// Generate prompts for the `Codellama-70b-instruct-hf` model.
 #[derive(Debug, Default, Clone)]
 pub struct CodeLlamaSuperInstructPrompt;
 impl CodeLlamaSuperInstructPrompt {
@@ -290,7 +282,7 @@ impl BuildChatPrompt for CodeLlamaSuperInstructPrompt {
             }
         }
 
-        prompt.push_str(" Destination:");
+        prompt.push_str(" Source: assistant\nDestination: user\n\n ");
 
         Ok(prompt)
     }

--- a/api-server/chat-prompts/src/chat/mod.rs
+++ b/api-server/chat-prompts/src/chat/mod.rs
@@ -40,6 +40,7 @@ pub enum ChatPrompt {
     MistralLitePrompt,
     OpenChatPrompt,
     CodeLlamaInstructPrompt,
+    CodeLlamaSuperInstructPrompt,
     HumanAssistantChatPrompt,
     /// Vicuna 1.0
     VicunaChatPrompt,

--- a/api-server/chat-prompts/src/lib.rs
+++ b/api-server/chat-prompts/src/lib.rs
@@ -10,6 +10,7 @@ pub enum PromptTemplateType {
     MistralLite,
     OpenChat,
     CodeLlama,
+    CodeLlamaSuper,
     HumanAssistant,
     VicunaChat,
     Vicuna11Chat,
@@ -35,6 +36,7 @@ impl FromStr for PromptTemplateType {
             "mistral-instruct" => Ok(PromptTemplateType::MistralInstruct),
             "mistrallite" => Ok(PromptTemplateType::MistralLite),
             "codellama-instruct" => Ok(PromptTemplateType::CodeLlama),
+            "codellama-super-instruct" => Ok(PromptTemplateType::CodeLlamaSuper),
             "belle-llama-2-chat" => Ok(PromptTemplateType::HumanAssistant),
             "human-assistant" => Ok(PromptTemplateType::HumanAssistant),
             "vicuna-chat" => Ok(PromptTemplateType::VicunaChat),
@@ -80,6 +82,7 @@ impl std::fmt::Display for PromptTemplateType {
             PromptTemplateType::SolarInstruct => write!(f, "solar-instruct"),
             PromptTemplateType::Phi2Chat => write!(f, "phi-2-chat"),
             PromptTemplateType::Phi2Instruct => write!(f, "phi-2-instruct"),
+            PromptTemplateType::CodeLlamaSuper => write!(f, "codellama-super-instruct"),
         }
     }
 }

--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -5,7 +5,7 @@ use crate::{
 use chat_prompts::{
     chat::{
         belle::HumanAssistantChatPrompt,
-        llama::{CodeLlamaInstructPrompt, Llama2ChatPrompt},
+        llama::{CodeLlamaInstructPrompt, CodeLlamaSuperInstructPrompt, Llama2ChatPrompt},
         mistral::{MistralInstructPrompt, MistralLitePrompt},
         openchat::OpenChatPrompt,
         BuildChatPrompt, ChatPrompt,
@@ -171,6 +171,9 @@ pub(crate) async fn chat_completions_handler(
             PromptTemplateType::OpenChat => ChatPrompt::OpenChatPrompt(OpenChatPrompt::default()),
             PromptTemplateType::CodeLlama => {
                 ChatPrompt::CodeLlamaInstructPrompt(CodeLlamaInstructPrompt::default())
+            }
+            PromptTemplateType::CodeLlamaSuper => {
+                ChatPrompt::CodeLlamaSuperInstructPrompt(CodeLlamaSuperInstructPrompt::default())
             }
             PromptTemplateType::HumanAssistant => {
                 ChatPrompt::HumanAssistantChatPrompt(HumanAssistantChatPrompt::default())

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -122,6 +122,7 @@ async fn main() -> Result<(), ServerError> {
                 .value_parser([
                     "llama-2-chat",
                     "codellama-instruct",
+                    "codellama-super-instruct",
                     "mistral-instruct-v0.1",
                     "mistral-instruct",
                     "mistrallite",

--- a/api-server/llama-api-server/src/main.rs
+++ b/api-server/llama-api-server/src/main.rs
@@ -174,10 +174,14 @@ async fn main() -> Result<(), ServerError> {
         .get_matches();
 
     // socket address
-    let socket_addr = matches
-        .get_one::<String>("socket_addr")
-        .unwrap()
-        .to_string();
+    let socket_addr = match matches.get_one::<String>("socket_addr") {
+        Some(socket_addr) => socket_addr.to_string(),
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `socket_addr` CLI option".to_owned(),
+            ));
+        }
+    };
     let addr: SocketAddr = match socket_addr.parse() {
         Ok(addr) => addr,
         Err(e) => {
@@ -190,14 +194,25 @@ async fn main() -> Result<(), ServerError> {
     );
 
     // model name
-    let model_name = matches.get_one::<String>("model_name").unwrap().to_string();
+    let model_name = match matches.get_one::<String>("model_name") {
+        Some(model_name) => model_name.to_string(),
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `model_name` CLI option".to_owned(),
+            ));
+        }
+    };
     println!("[INFO] Model name: {name}", name = &model_name);
 
     // model alias
-    let model_alias = matches
-        .get_one::<String>("model_alias")
-        .unwrap()
-        .to_string();
+    let model_alias = match matches.get_one::<String>("model_alias") {
+        Some(model_alias) => model_alias.to_string(),
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `model_alias` CLI option".to_owned(),
+            ));
+        }
+    };
     println!("[INFO] Model alias: {alias}", alias = &model_alias);
 
     // create a `ModelInfo` instance
@@ -207,7 +222,14 @@ async fn main() -> Result<(), ServerError> {
     let mut options = Metadata::default();
 
     // prompt context size
-    let ctx_size = matches.get_one::<u32>("ctx_size").unwrap();
+    let ctx_size = match matches.get_one::<u32>("ctx_size") {
+        Some(ctx_size) => ctx_size,
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `ctx_size` CLI option".to_owned(),
+            ));
+        }
+    };
     println!("[INFO] Prompt context size: {size}", size = ctx_size);
     options.ctx_size = *ctx_size as u64;
 
@@ -221,12 +243,26 @@ async fn main() -> Result<(), ServerError> {
     }
 
     // number of tokens to predict
-    let n_predict = matches.get_one::<u32>("n_predict").unwrap();
+    let n_predict = match matches.get_one::<u32>("n_predict") {
+        Some(n_predict) => n_predict,
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `n_predict` CLI option".to_owned(),
+            ));
+        }
+    };
     println!("[INFO] Number of tokens to predict: {n}", n = n_predict);
     options.n_predict = *n_predict as u64;
 
     // n_gpu_layers
-    let n_gpu_layers = matches.get_one::<u32>("n_gpu_layers").unwrap();
+    let n_gpu_layers = match matches.get_one::<u32>("n_gpu_layers") {
+        Some(n_gpu_layers) => n_gpu_layers,
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `n_gpu_layers` CLI option".to_owned(),
+            ));
+        }
+    };
     println!(
         "[INFO] Number of layers to run on the GPU: {n}",
         n = n_gpu_layers
@@ -234,7 +270,14 @@ async fn main() -> Result<(), ServerError> {
     options.n_gpu_layers = *n_gpu_layers as u64;
 
     // batch size
-    let batch_size = matches.get_one::<u32>("batch_size").unwrap();
+    let batch_size = match matches.get_one::<u32>("batch_size") {
+        Some(batch_size) => batch_size,
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `batch_size` CLI option".to_owned(),
+            ));
+        }
+    };
     println!(
         "[INFO] Batch size for prompt processing: {size}",
         size = batch_size
@@ -242,12 +285,26 @@ async fn main() -> Result<(), ServerError> {
     options.batch_size = *batch_size as u64;
 
     // temperature
-    let temp = matches.get_one::<f32>("temp").unwrap();
+    let temp = match matches.get_one::<f32>("temp") {
+        Some(temp) => temp,
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `temp` CLI option".to_owned(),
+            ));
+        }
+    };
     println!("[INFO] Temperature for sampling: {temp}", temp = temp);
     options.temp = *temp;
 
     // repeat penalty
-    let repeat_penalty = matches.get_one::<f32>("repeat_penalty").unwrap();
+    let repeat_penalty = match matches.get_one::<f32>("repeat_penalty") {
+        Some(repeat_penalty) => repeat_penalty,
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `repeat_penalty` CLI option".to_owned(),
+            ));
+        }
+    };
     println!(
         "[INFO] Penalize repeat sequence of tokens: {penalty}",
         penalty = repeat_penalty
@@ -261,10 +318,14 @@ async fn main() -> Result<(), ServerError> {
     }
 
     // type of prompt template
-    let prompt_template = matches
-        .get_one::<String>("prompt_template")
-        .unwrap()
-        .to_string();
+    let prompt_template = match matches.get_one::<String>("prompt_template") {
+        Some(prompt_template) => prompt_template.to_string(),
+        None => {
+            return Err(ServerError::InternalServerError(
+                "Failed to parse the value of `prompt_template` CLI option".to_owned(),
+            ))
+        }
+    };
     let template_ty = match PromptTemplateType::from_str(&prompt_template) {
         Ok(template) => template,
         Err(e) => {
@@ -306,7 +367,24 @@ async fn main() -> Result<(), ServerError> {
         return Err(ServerError::Metadata);
     }
 
-    let graph = Graph::new(model_alias, METADATA.get().unwrap());
+    let graph = {
+        let metadata = match METADATA.get() {
+            Some(metadata) => metadata,
+            None => {
+                return Err(ServerError::InternalServerError(
+                    "The METADATA is not set".to_owned(),
+                ));
+            }
+        };
+
+        match Graph::new(model_alias, metadata) {
+            Ok(graph) => graph,
+            Err(e) => {
+                return Err(ServerError::InternalServerError(e.to_string()));
+            }
+        }
+    };
+
     if GRAPH.set(Mutex::new(graph)).is_err() {
         return Err(ServerError::InternalServerError(
             "The GRAPH has already been initialized".to_owned(),
@@ -314,19 +392,66 @@ async fn main() -> Result<(), ServerError> {
     }
 
     {
-        let graph = GRAPH.get().unwrap().lock().unwrap();
+        let graph = match GRAPH.get() {
+            Some(graph) => graph,
+            None => {
+                return Err(ServerError::InternalServerError(
+                    "The GRAPH is not set".to_owned(),
+                ));
+            }
+        };
+
+        let graph_locked = match graph.lock() {
+            Ok(graph) => graph,
+            Err(e) => {
+                return Err(ServerError::InternalServerError(e.to_string()));
+            }
+        };
 
         // get version info
-        let max_output_size = *MAX_BUFFER_SIZE.get().unwrap();
+        let max_output_size = match MAX_BUFFER_SIZE.get() {
+            Some(max_output_size) => *max_output_size,
+            None => {
+                return Err(ServerError::InternalServerError(
+                    "The MAX_BUFFER_SIZE is not set".to_owned(),
+                ));
+            }
+        };
         let mut output_buffer = vec![0u8; max_output_size];
-        let mut output_size = graph.get_output(1, &mut output_buffer).unwrap();
+        let mut output_size = match graph_locked.get_output(1, &mut output_buffer) {
+            Ok(output_size) => output_size,
+            Err(e) => {
+                return Err(ServerError::InternalServerError(e.to_string()));
+            }
+        };
         output_size = std::cmp::min(max_output_size, output_size);
         let metadata: serde_json::Value =
-            serde_json::from_slice(&output_buffer[..output_size]).unwrap();
+            match serde_json::from_slice(&output_buffer[..output_size]) {
+                Ok(metadata) => metadata,
+                Err(e) => {
+                    return Err(ServerError::InternalServerError(e.to_string()));
+                }
+            };
+
+        let plugin_build_number = match metadata["llama_build_number"].as_u64() {
+            Some(build_number) => build_number,
+            None => {
+                return Err(ServerError::InternalServerError(
+                    "Failed to convert the build number of the plugin to u64".to_owned(),
+                ));
+            }
+        };
+        let plugin_commit = match metadata["llama_commit"].as_str() {
+            Some(commit) => commit,
+            None => {
+                return Err(ServerError::InternalServerError(
+                    "Failed to convert the commit id of the plugin to string".to_owned(),
+                ));
+            }
+        };
         println!(
             "[INFO] Plugin version: b{} (commit {})",
-            metadata["llama_build_number"].as_u64().unwrap(),
-            metadata["llama_commit"].as_str().unwrap(),
+            plugin_build_number, plugin_commit,
         );
     }
 
@@ -335,10 +460,13 @@ async fn main() -> Result<(), ServerError> {
     }
 
     // the timestamp when the server is created
-    let created = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let created = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs(),
+        Err(e) => {
+            return Err(ServerError::InternalServerError(e.to_string()));
+        }
+    };
+
     let ref_created = std::sync::Arc::new(created);
 
     let new_service = make_service_fn(move |_| {
@@ -463,8 +591,8 @@ pub(crate) struct Graph {
     context: GraphExecutionContext,
 }
 impl Graph {
-    pub fn new(model_alias: impl AsRef<str>, options: &Metadata) -> Self {
-        let config = serde_json::to_string(&options).unwrap();
+    pub fn new(model_alias: impl AsRef<str>, options: &Metadata) -> Result<Self, String> {
+        let config = serde_json::to_string(&options).map_err(|e| e.to_string())?;
 
         // load the model
         let graph = wasi_nn::GraphBuilder::new(
@@ -473,15 +601,15 @@ impl Graph {
         )
         .config(config)
         .build_from_cache(model_alias.as_ref())
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
         // initialize the execution context
-        let context = graph.init_execution_context().unwrap();
+        let context = graph.init_execution_context().map_err(|e| e.to_string())?;
 
-        Self {
+        Ok(Self {
             _graph: graph,
             context,
-        }
+        })
     }
 
     pub fn set_input<T: Sized>(

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 
 [dependencies]

--- a/chat/README.md
+++ b/chat/README.md
@@ -133,7 +133,7 @@ Options:
   -s, --system-prompt <SYSTEM_PROMPT>
           System prompt message string [default: "[Default system message for the prompt template]"]
   -p, --prompt-template <TEMPLATE>
-          Prompt template. [default: llama-2-chat] [possible values: llama-2-chat, codellama-instruct, mistral-instruct-v0.1, mistral-instruct, mistrallite, openchat, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct]
+          Prompt template. [default: llama-2-chat] [possible values: llama-2-chat, codellama-instruct, codellama-super-instruct, mistral-instruct-v0.1, mistral-instruct, mistrallite, openchat, human-assistant, vicuna-1.0-chat, vicuna-1.1-chat, chatml, baichuan-2, wizard-coder, zephyr, stablelm-zephyr, intel-neural, deepseek-chat, deepseek-coder, solar-instruct, phi-2-chat, phi-2-instruct]
       --log-prompts
           Print prompt strings to stdout
       --log-stat

--- a/chat/src/error.rs
+++ b/chat/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum ChatError {
     #[error("Context full")]
     ContextFull(String),
+    #[error("The prompt is too long")]
+    PromptTooLong,
     #[error("Fail to compute")]
     Operation(String),
 }

--- a/chat/src/main.rs
+++ b/chat/src/main.rs
@@ -101,6 +101,7 @@ fn main() -> Result<(), String> {
                 .value_parser([
                     "llama-2-chat",
                     "codellama-instruct",
+                    "codellama-super-instruct",
                     "mistral-instruct-v0.1",
                     "mistral-instruct",
                     "mistrallite",
@@ -592,6 +593,9 @@ fn create_prompt_template(template_ty: PromptTemplateType) -> ChatPrompt {
         }
         PromptTemplateType::CodeLlama => ChatPrompt::CodeLlamaInstructPrompt(
             chat_prompts::chat::llama::CodeLlamaInstructPrompt::default(),
+        ),
+        PromptTemplateType::CodeLlamaSuper => ChatPrompt::CodeLlamaSuperInstructPrompt(
+            chat_prompts::chat::llama::CodeLlamaSuperInstructPrompt::default(),
         ),
         PromptTemplateType::HumanAssistant => ChatPrompt::HumanAssistantChatPrompt(
             chat_prompts::chat::belle::HumanAssistantChatPrompt::default(),

--- a/run-llm.sh
+++ b/run-llm.sh
@@ -191,7 +191,7 @@ if [[ "$reinstall_wasmedge" == "1" ]]; then
     if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml; then
         source $HOME/.wasmedge/env
         wasmedge_path=$(which wasmedge)
-        printf "\n    The WasmEdge Runtime is installed in %s.\n\n    * To uninstall it, use the command 'bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -q'\n\n" "$wasmedge_path"
+        printf "\n    The WasmEdge Runtime is installed in %s.\n\n" "$wasmedge_path"
     else
         echo "Failed to install WasmEdge"
         exit 1

--- a/run-llm.sh
+++ b/run-llm.sh
@@ -187,21 +187,13 @@ while [[ "$reinstall_wasmedge" -ne 1 && "$reinstall_wasmedge" -ne 2 ]]; do
 done
 
 if [[ "$reinstall_wasmedge" == "1" ]]; then
-    # uninstall WasmEdge
-    if bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -q; then
-
-        # install WasmEdge + wasi-nn_ggml plugin
-        if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml; then
-            source $HOME/.wasmedge/env
-            wasmedge_path=$(which wasmedge)
-            printf "\n    The WasmEdge Runtime is installed in %s.\n\n    * To uninstall it, use the command 'bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -q'\n\n" "$wasmedge_path"
-        else
-            echo "Failed to install WasmEdge"
-            exit 1
-        fi
-
+    # install WasmEdge + wasi-nn_ggml plugin
+    if curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml; then
+        source $HOME/.wasmedge/env
+        wasmedge_path=$(which wasmedge)
+        printf "\n    The WasmEdge Runtime is installed in %s.\n\n    * To uninstall it, use the command 'bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -q'\n\n" "$wasmedge_path"
     else
-        echo "Failed to uninstall WasmEdge"
+        echo "Failed to install WasmEdge"
         exit 1
     fi
 

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- Llama-chat
  - Improve the reliability of handling errors

- `run-llm.sh`
  - Refactor the download of `llama-api-server.wasm` and `llama-chat.wasm`
  - Remove the un-necessary uninstallation step

- Prompt type: `codellama-super-instruct`

- New model: [second-state/CodeLlama-70b-Instruct-hf-GGUF](https://huggingface.co/second-state/CodeLlama-70b-Instruct-hf-GGUF)

