### PR TITLE
Release 0.2.13

### DIFF
--- a/api-server/llama-api-server/Cargo.toml
+++ b/api-server/llama-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-api-server"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 
 [dependencies]

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -380,10 +380,6 @@ pub(crate) async fn chat_completions_handler(
                                 let output = String::from_utf8_lossy(&output_buffer[..output_size])
                                     .to_string();
 
-                                // ! debug
-                                println!("{:?}", &output);
-
-                                // let stop = &*reverse_prompt.clone();
                                 if let Some(stop) = &*reverse_prompt.clone() {
                                     if output == *stop {
                                         let created = match SystemTime::now()

--- a/api-server/llama-api-server/src/backend/ggml.rs
+++ b/api-server/llama-api-server/src/backend/ggml.rs
@@ -436,6 +436,12 @@ pub(crate) async fn chat_completions_handler(
                                         finish_reason: Some(FinishReason::stop),
                                     }],
                                 };
+
+                                if let Err(e) = graph.finish_single() {
+                                    println!("Error: {:?}", &e);
+                                    return Err(e.to_string());
+                                }
+
                                 one_more_run_then_stop = false;
 
                                 // serialize chat completion chunk

--- a/chat/Cargo.toml
+++ b/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-chat"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 
 [dependencies]

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-simple"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Major changes:

- Llama-api-server
  - Clear the context after each round of conversation in the streaming mode
  - Add the additional checking code to stop generation in the streaming mode